### PR TITLE
Perform mimimal null safety migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+
+- Upgrade to Dart 3 (incl. null safety)
+
 ## 1.1.2
 
 - Improve example and README.md.

--- a/example/howler_example.dart
+++ b/example/howler_example.dart
@@ -2,21 +2,22 @@ import 'package:howler/howler.dart';
 
 void main() {
   var howl = Howl(
-      src: [
-        'audio/track.mp3',
-        'audio/track.wav'
-      ], // source in MP3 and WAV fallback
-      loop: true, // Loops the sound when play ends.
-      volume: 0.60, // Play with 60% of original volume.
-      preload: false // Automatically loads source.
-      );
+    src: [
+      'audio/track.mp3',
+      'audio/track.wav',
+    ], // source in MP3 and WAV fallback
+    loop: true, // Loops the sound when play ends.
+    volume: 0.60, // Play with 60% of original volume.
+    preload: false, // Automatically loads source.
+  );
 
   // Calls `load` and after 'load' event, calls `play` and `callback`:
   howl.loadAndPlay(
-      safe: true, // Checks for initial user interaction before play.
-      callback: () {
-        // Callback is called only after play call.
-        // Make a fade, from volume 0% to 60% in 10s:
-        howl.fade(0.0, 0.60, 10000);
-      });
+    safe: true, // Checks for initial user interaction before play.
+    callback: () {
+      // Callback is called only after play call.
+      // Make a fade, from volume 0% to 60% in 10s:
+      howl.fade(0.0, 0.60, 10000);
+    },
+  );
 }

--- a/lib/src/howler_base.dart
+++ b/lib/src/howler_base.dart
@@ -225,8 +225,10 @@ class _HowlerGlobal {
 
     // With Web Audio, we just need to mute the master gain.
     if (usingWebAudio) {
-      masterGain.gain!
-          .setValueAtTime(muted ? 0 : _volume, Howler.ctx!.currentTime!);
+      masterGain.gain!.setValueAtTime(
+        muted ? 0 : _volume,
+        Howler.ctx!.currentTime!,
+      );
     }
 
     // Loop through and mute all HTML5 Audio nodes.
@@ -267,7 +269,7 @@ class _HowlerGlobal {
     }
 
     // Create a new AudioContext to make sure it is fully reset.
-    if (usingWebAudio && ctx != null && ctx!.close != null) {
+    if (usingWebAudio && ctx != null) {
       ctx!.close();
       ctx = null;
       _setupAudioContext();
@@ -334,8 +336,6 @@ class _HowlerGlobal {
       return this;
     }
 
-    if (audioTest == null) return this;
-
     var mpegTest = canPlayType(audioTest, 'audio/mpeg;');
 
     _codecs = {
@@ -347,20 +347,24 @@ class _HowlerGlobal {
       'wav': canPlayType(audioTest, 'audio/wav; codecs="1"'),
       'aac': canPlayType(audioTest, 'audio/aac;'),
       'caf': canPlayType(audioTest, 'audio/x-caf;'),
-      'm4a': canPlayType(audioTest, 'audio/x-m4a;') ||
+      'm4a':
+          canPlayType(audioTest, 'audio/x-m4a;') ||
           canPlayType(audioTest, 'audio/m4a;') ||
           canPlayType(audioTest, 'audio/aac;'),
-      'm4b': canPlayType(audioTest, 'audio/x-m4b;') ||
+      'm4b':
+          canPlayType(audioTest, 'audio/x-m4b;') ||
           canPlayType(audioTest, 'audio/m4b;') ||
           canPlayType(audioTest, 'audio/aac;'),
-      'mp4': canPlayType(audioTest, 'audio/x-mp4;') ||
+      'mp4':
+          canPlayType(audioTest, 'audio/x-mp4;') ||
           canPlayType(audioTest, 'audio/mp4;') ||
           canPlayType(audioTest, 'audio/aac;'),
       'weba': canPlayType(audioTest, 'audio/webm; codecs="vorbis"'),
       'webm': canPlayType(audioTest, 'audio/webm; codecs="vorbis"'),
       'dolby': canPlayType(audioTest, 'audio/mp4; codecs="ec-3"'),
-      'flac': canPlayType(audioTest, 'audio/x-flac;') ||
-          canPlayType(audioTest, 'audio/flac;')
+      'flac':
+          canPlayType(audioTest, 'audio/x-flac;') ||
+          canPlayType(audioTest, 'audio/flac;'),
     };
 
     return this;
@@ -368,7 +372,7 @@ class _HowlerGlobal {
 
   static bool canPlayType(AudioElement audioTest, String type) {
     var canPlayType = audioTest.canPlayType('audio/mp3;');
-    if (canPlayType == null || canPlayType.isEmpty) return false;
+    if (canPlayType.isEmpty) return false;
     canPlayType = canPlayType.toLowerCase();
     return canPlayType != 'no';
   }
@@ -499,12 +503,11 @@ class _HowlerGlobal {
     //.Check if the audio is locked and throw a warning.
     var testPlay = AudioElement().play();
 
-    if (testPlay != null) {
-      testPlay.catchError((_) {
-        window.console.warn(
-            'HTML5 Audio pool exhausted, returning potentially locked audio object.');
-      });
-    }
+    testPlay.catchError((_) {
+      window.console.warn(
+        'HTML5 Audio pool exhausted, returning potentially locked audio object.',
+      );
+    });
 
     return AudioElement();
   }
@@ -563,11 +566,14 @@ class _HowlerGlobal {
         }
       };
 
-      ctx!.suspend().then((_) {
-        handleSuspension();
-      }, onError: (_) {
-        handleSuspension();
-      });
+      ctx!.suspend().then(
+        (_) {
+          handleSuspension();
+        },
+        onError: (_) {
+          handleSuspension();
+        },
+      );
     });
 
     return this;
@@ -610,8 +616,8 @@ class _HowlerGlobal {
 
 final _HowlerGlobal Howler = _HowlerGlobal();
 
-typedef HowlEventListener = Function(
-    Howl howl, String eventType, int? id, String? message);
+typedef HowlEventListener =
+    Function(Howl howl, String eventType, int? id, String? message);
 
 class _HowlEventListenerWrapper {
   final int? id;
@@ -669,7 +675,7 @@ class _HowlSpriteParams {
   int? to;
   bool? loop;
 
-  _HowlSpriteParams(this.from, this.to, [this.loop = false]);
+  _HowlSpriteParams(this.from, this.to);
 
   _HowlSpriteParams.list(List params) {
     from = int.parse(params[0].toString());
@@ -684,7 +690,8 @@ class _HowlSpriteParams {
   }
 
   static Map<String, _HowlSpriteParams> toMapOfSpritesParams(
-      Map<String, List> map) {
+    Map<String, List> map,
+  ) {
     var sprites = <String, _HowlSpriteParams>{};
 
     for (var entry in map.entries) {
@@ -781,40 +788,42 @@ class Howl {
 
   late bool _webAudio;
 
-  Howl(
-      {List<String>? src,
-      bool autoplay = false,
-      List<String>? format,
-      bool html5 = false,
-      bool mute = false,
-      bool loop = false,
-      int pool = 5,
-      bool preload = true,
-      double rate = 1,
-      Map<String, List>? sprite,
-      double volume = 1,
-      String xhrMethod = 'GET',
-      bool xhrWithCredentials = false,
-      Map<String, String>? xhrHeaders,
-      HowlEventListener? onend,
-      HowlEventListener? onfade,
-      HowlEventListener? onload,
-      HowlEventListener? onloaderror,
-      HowlEventListener? onplayerror,
-      HowlEventListener? onpause,
-      HowlEventListener? onplay,
-      HowlEventListener? onstop,
-      HowlEventListener? onmute,
-      HowlEventListener? onvolume,
-      HowlEventListener? onrate,
-      HowlEventListener? onseek,
-      HowlEventListener? onunlock,
-      HowlEventListener? onresume}) {
+  Howl({
+    List<String>? src,
+    bool autoplay = false,
+    List<String>? format,
+    bool html5 = false,
+    bool mute = false,
+    bool loop = false,
+    int pool = 5,
+    bool preload = true,
+    double rate = 1,
+    Map<String, List>? sprite,
+    double volume = 1,
+    String xhrMethod = 'GET',
+    bool xhrWithCredentials = false,
+    Map<String, String>? xhrHeaders,
+    HowlEventListener? onend,
+    HowlEventListener? onfade,
+    HowlEventListener? onload,
+    HowlEventListener? onloaderror,
+    HowlEventListener? onplayerror,
+    HowlEventListener? onpause,
+    HowlEventListener? onplay,
+    HowlEventListener? onstop,
+    HowlEventListener? onmute,
+    HowlEventListener? onvolume,
+    HowlEventListener? onrate,
+    HowlEventListener? onseek,
+    HowlEventListener? onunlock,
+    HowlEventListener? onresume,
+  }) {
     _DetectUserInteraction.detect();
 
     if (src == null || src.isEmpty) {
-      window.console
-          .error('An array of source files must be passed with any new Howl.');
+      window.console.error(
+        'An array of source files must be passed with any new Howl.',
+      );
       return;
     }
 
@@ -832,12 +841,13 @@ class Howl {
     _pool = pool;
     _preload = preload;
     _rate = rate;
-    _sprite =
-        sprite != null ? _HowlSpriteParams.toMapOfSpritesParams(sprite) : {};
+    _sprite = sprite != null
+        ? _HowlSpriteParams.toMapOfSpritesParams(sprite)
+        : {};
     _src = _HowlSrc.list(src);
     _volume = volume;
 
-    xhrMethod = (xhrMethod ?? 'GET').trim().toUpperCase();
+    xhrMethod = xhrMethod.trim().toUpperCase();
     _xhrMethod = xhrMethod.isNotEmpty ? xhrMethod : 'GET';
 
     _xhrWithCredentials = xhrWithCredentials;
@@ -855,10 +865,12 @@ class Howl {
     _onend = onend != null ? [_HowlEventListenerWrapper(onend)] : [];
     _onfade = onfade != null ? [_HowlEventListenerWrapper(onfade)] : [];
     _onload = onload != null ? [_HowlEventListenerWrapper(onload)] : [];
-    _onloaderror =
-        onloaderror != null ? [_HowlEventListenerWrapper(onloaderror)] : [];
-    _onplayerror =
-        onplayerror != null ? [_HowlEventListenerWrapper(onplayerror)] : [];
+    _onloaderror = onloaderror != null
+        ? [_HowlEventListenerWrapper(onloaderror)]
+        : [];
+    _onplayerror = onplayerror != null
+        ? [_HowlEventListenerWrapper(onplayerror)]
+        : [];
     _onpause = onpause != null ? [_HowlEventListenerWrapper(onpause)] : [];
     _onplay = onplay != null ? [_HowlEventListenerWrapper(onplay)] : [];
     _onstop = onstop != null ? [_HowlEventListenerWrapper(onstop)] : [];
@@ -901,8 +913,6 @@ class Howl {
   /// Calls [load] than [play] and [callback] when load event happens.
   /// If [this] is already loaded, [play] and [callback] are called immediately.
   Howl loadAndPlay({dynamic sprite, bool safe = true, _SimpleCall? callback}) {
-    safe ??= true;
-
     if (isLoaded) {
       load();
 
@@ -963,20 +973,17 @@ class Howl {
     for (var i = 0; i < _src!.length; i++) {
       String? ext, src;
 
-      if (_format != null && i < _format!.length && _format![i] != null) {
+      if (_format != null && i < _format!.length) {
         // If an extension was specified, use that instead.
         ext = _format![i];
       } else {
         // Make sure the source is a string.
         src = _src![i];
-        if (src == null) {
-          _emit('loaderror', null,
-              'Non-string found in selected audio sources - ignoring.');
-          continue;
-        }
 
-        var match = RegExp(r'^data:audio/([^;,]+);', caseSensitive: false)
-            .firstMatch(src);
+        var match = RegExp(
+          r'^data:audio/([^;,]+);',
+          caseSensitive: false,
+        ).firstMatch(src);
         ext = match != null ? match.group(1) : null;
 
         if (ext == null || ext.isEmpty) {
@@ -993,7 +1000,8 @@ class Howl {
       // Log a warning if no extension was found.
       if (ext == null) {
         window.console.warn(
-            'No file extension was found. Consider using the "format" property or specify an extension.');
+          'No file extension was found. Consider using the "format" property or specify an extension.',
+        );
       }
 
       // Check if this extension is available.
@@ -1048,8 +1056,11 @@ class Howl {
   ///
   /// If user hasn't interacted yet, this call will be put in a queue to be
   /// flushed when interaction is detected.
-  int? playSafe(
-      {dynamic sprite, bool internal = false, _SimpleCall? callback}) {
+  int? playSafe({
+    dynamic sprite,
+    bool internal = false,
+    _SimpleCall? callback,
+  }) {
     if (userInitialInteractionDetected) {
       var id = play(sprite, internal);
       _doCall(callback);
@@ -1130,9 +1141,11 @@ class Howl {
       // Add the sound to the queue to be played on load.
       var soundId = sound._id;
 
-      _queue.add(_HowlCall('play', () {
-        play(soundId);
-      }));
+      _queue.add(
+        _HowlCall('play', () {
+          play(soundId);
+        }),
+      );
 
       return soundId;
     }
@@ -1154,9 +1167,13 @@ class Howl {
 
     // Determine how long to play for and where to start playing.
     var seek = Math.max(
-        0, sound._seek! > 0 ? sound._seek! : _sprite[sprite]!.from! / 1000);
+      0,
+      sound._seek! > 0 ? sound._seek! : _sprite[sprite]!.from! / 1000,
+    );
     var duration = Math.max(
-        0, ((_sprite[sprite]!.from! + _sprite[sprite]!.to!) / 1000) - seek);
+      0,
+      ((_sprite[sprite]!.from! + _sprite[sprite]!.to!) / 1000) - seek,
+    );
     var timeout = (duration * 1000) ~/ sound._rate!.abs();
 
     var start = _sprite[sprite]!.from! / 1000;
@@ -1211,8 +1228,10 @@ class Howl {
 
         // Start a new timer if none is present.
         if (timeout > 0 && timeout < 100000000) {
-          _endTimers[sound._id] =
-              Timer(Duration(milliseconds: timeout), () => _ended(sound));
+          _endTimers[sound._id] = Timer(
+            Duration(milliseconds: timeout),
+            () => _ended(sound),
+          );
         }
 
         if (!internal) {
@@ -1247,40 +1266,36 @@ class Howl {
         try {
           var play = node.audio!.play();
 
-          if (play != null) {
-            // Implements a lock to prevent DOMException: The play() request was interrupted by a call to pause().
-            _playLock = true;
+          // Implements a lock to prevent DOMException: The play() request was interrupted by a call to pause().
+          _playLock = true;
 
-            // Set param values immediately.
-            setParams();
+          // Set param values immediately.
+          setParams();
 
-            // Releases the lock and executes queued actions.
-            play.then((_) {
-              _playLock = false;
-              node._unlocked = true;
+          // Releases the lock and executes queued actions.
+          play
+              .then((_) {
+                _playLock = false;
+                node._unlocked = true;
 
-              if (!internal) {
-                _emit('play', sound._id);
-                _loadQueue();
-              }
-            }).catchError(() {
-              _playLock = false;
-              _emit(
+                if (!internal) {
+                  _emit('play', sound._id);
+                  _loadQueue();
+                }
+              })
+              .catchError((e) {
+                _playLock = false;
+                _emit(
                   'playerror',
                   sound._id,
                   'Playback was unable to start. This is most commonly an issue '
-                      'on mobile devices and Chrome where playback was not within a user interaction.');
+                      'on mobile devices and Chrome where playback was not within a user interaction.',
+                );
 
-              // Reset the ended and paused values.
-              sound._ended = true;
-              sound._paused = true;
-            });
-          } else if (!internal) {
-            _playLock = false;
-            setParams();
-            _emit('play', sound._id);
-            _loadQueue();
-          }
+                // Reset the ended and paused values.
+                sound._ended = true;
+                sound._paused = true;
+              });
 
           // Setting rate before playing won't work in IE, so we set it again here.
           node.audio!.playbackRate = sound._rate!;
@@ -1288,10 +1303,11 @@ class Howl {
           // If the node is still paused, then we can assume there was a playback issue.
           if (node.audio!.paused) {
             _emit(
-                'playerror',
-                sound._id,
-                'Playback was unable to start. This is most commonly an issue '
-                    'on mobile devices and Chrome where playback was not within a user interaction.');
+              'playerror',
+              sound._id,
+              'Playback was unable to start. This is most commonly an issue '
+                  'on mobile devices and Chrome where playback was not within a user interaction.',
+            );
             return;
           }
 
@@ -1309,8 +1325,11 @@ class Howl {
               _clearTimer(sound._id);
             };
 
-            node.eventTarget!
-                .addEventListener('ended', _endTimers[sound._id], false);
+            node.eventTarget!.addEventListener(
+              'ended',
+              _endTimers[sound._id],
+              false,
+            );
           }
         } catch (err) {
           _emit('playerror', sound._id, err.toString());
@@ -1341,8 +1360,11 @@ class Howl {
           _clearTimer(sound._id);
         };
 
-        node.eventTarget!
-            .addEventListener(Howler._canPlayEvent, listener, false);
+        node.eventTarget!.addEventListener(
+          Howler._canPlayEvent,
+          listener,
+          false,
+        );
       }
     }
 
@@ -1506,11 +1528,7 @@ class Howl {
 
     // If applying mute/unmute to all sounds, update the group's value.
     if (id == null) {
-      if (muted != null) {
-        _muted = muted;
-      } else {
-        return this;
-      }
+      _muted = muted;
     }
 
     // If no id is passed, get all ID's to be muted.
@@ -1530,7 +1548,9 @@ class Howl {
 
         if (_webAudio && sound._node != null) {
           sound._node!.gainNode!.gain!.setValueAtTime(
-              muted ? 0 : sound._volume!, Howler.ctx!.currentTime!);
+            muted ? 0 : sound._volume!,
+            Howler.ctx!.currentTime!,
+          );
         } else if (sound._node != null) {
           sound._node!.audio!.muted = Howler._muted ? true : muted;
         }
@@ -1593,8 +1613,10 @@ class Howl {
         }
 
         if (_webAudio && sound._node != null && !sound._muted!) {
-          sound._node!.gainNode!.gain!
-              .setValueAtTime(vol, Howler.ctx!.currentTime!);
+          sound._node!.gainNode!.gain!.setValueAtTime(
+            vol,
+            Howler.ctx!.currentTime!,
+          );
         } else if (sound._node != null && !sound._muted!) {
           sound._node!.audio!.volume = vol * Howler.volume();
         }
@@ -1610,8 +1632,13 @@ class Howl {
   ///
   /// If user hasn't interacted yet, this call will be put in a queue to be
   /// flushed when interaction is detected.
-  Howl fadeSafe(double from, double to, int len,
-      {int? id, _SimpleCall? callback}) {
+  Howl fadeSafe(
+    double from,
+    double to,
+    int len, {
+    int? id,
+    _SimpleCall? callback,
+  }) {
     if (userInitialInteractionDetected) {
       fade(from, to, len, id);
       _doCall(callback);
@@ -1691,7 +1718,13 @@ class Howl {
   /// @param  {Number} id   The sound id to fade.
   /// @param  {Boolean} isGroup   If true, set the volume on the group.
   void _startFadeInterval(
-      Sound sound, double from, double to, int len, id, isGroup) {
+    Sound sound,
+    double from,
+    double to,
+    int len,
+    id,
+    isGroup,
+  ) {
     var vol = from;
     var diff = to - from;
     var steps = (diff / 0.01).abs();
@@ -1757,8 +1790,9 @@ class Howl {
 
     if (sound != null && sound._interval != null) {
       if (_webAudio) {
-        sound._node!.gainNode!.gain!
-            .cancelScheduledValues(Howler.ctx!.currentTime!);
+        sound._node!.gainNode!.gain!.cancelScheduledValues(
+          Howler.ctx!.currentTime!,
+        );
       }
 
       sound._interval!.cancel();
@@ -1862,8 +1896,9 @@ class Howl {
         // start position so we can properly adjust the seek position for time elapsed.
         if (playing(id2)) {
           sound._rateSeek = getSeek(id2);
-          sound._playStart =
-              _webAudio ? Howler.ctx!.currentTime as double? : sound._playStart;
+          sound._playStart = _webAudio
+              ? Howler.ctx!.currentTime as double?
+              : sound._playStart;
         }
         sound._rate = rate;
 
@@ -1871,8 +1906,10 @@ class Howl {
         if (_webAudio &&
             sound._node != null &&
             sound._node!.bufferSource != null) {
-          sound._node!.bufferSource!.playbackRate!
-              .setValueAtTime(rate, Howler.ctx!.currentTime!);
+          sound._node!.bufferSource!.playbackRate!.setValueAtTime(
+            rate,
+            Howler.ctx!.currentTime!,
+          );
         } else if (sound._node != null) {
           sound._node!.audio!.playbackRate = rate;
         }
@@ -1881,8 +1918,8 @@ class Howl {
         var seek = getSeek(id2)!;
         var duration =
             ((_sprite[sound._sprite]!.from! + _sprite[sound._sprite]!.to!) /
-                    1000) -
-                seek;
+                1000) -
+            seek;
         var timeout = (duration * 1000) ~/ sound._rate!.abs();
 
         // Start a new end timer if sound is already playing.
@@ -1923,8 +1960,9 @@ class Howl {
 
     if (sound != null) {
       if (_webAudio) {
-        double realTime =
-            playing(id) ? Howler.ctx!.currentTime! - sound._playStart! : 0;
+        var realTime = playing(id)
+            ? Howler.ctx!.currentTime! - sound._playStart!
+            : 0;
         var rateSeek = sound._rateSeek != null && sound._rateSeek! > 0
             ? sound._rateSeek! - sound._seek!
             : 0;
@@ -2062,10 +2100,16 @@ class Howl {
         _clearSound(sounds[i]._node);
 
         // Remove any event listeners.
-        sound._node!.eventTarget!
-            .removeEventListener('error', sound._errorFn, false);
-        sound._node!.eventTarget!
-            .removeEventListener(Howler._canPlayEvent, sound._loadFn, false);
+        sound._node!.eventTarget!.removeEventListener(
+          'error',
+          sound._errorFn,
+          false,
+        );
+        sound._node!.eventTarget!.removeEventListener(
+          Howler._canPlayEvent,
+          sound._loadFn,
+          false,
+        );
 
         // Release the Audio object back to the pool.
         Howler._releaseHtml5Audio(sound._node!);
@@ -2114,8 +2158,12 @@ class Howl {
   /// @param  {Number}   id    (optional) Only listen to events for this sound.
   /// @param  {Number}   once  (INTERNAL) Marks event to fire only once.
   /// @return {Howl}
-  Howl on(String eventType, HowlEventListener function,
-      [int? id, bool once = false]) {
+  Howl on(
+    String eventType,
+    HowlEventListener function, [
+    int? id,
+    bool once = false,
+  ]) {
     var events = _getEventListeners(eventType)!;
     var listener = _HowlEventListenerWrapper(function, id, once);
     events.add(listener);
@@ -2210,26 +2258,32 @@ class Howl {
         withCredentials: _xhrWithCredentials,
         requestHeaders: _xhrHeaders,
         responseType: 'arraybuffer',
-      ).then((xhr) {
-        // Make sure we get a successful response back.
-        var code = xhr.status!;
-        if (code < 200 || code >= 400) {
-          _emit('loaderror', null,
-              'Failed loading audio file with status: $code');
-          return;
-        }
+      ).then(
+        (xhr) {
+          // Make sure we get a successful response back.
+          var code = xhr.status!;
+          if (code < 200 || code >= 400) {
+            _emit(
+              'loaderror',
+              null,
+              'Failed loading audio file with status: $code',
+            );
+            return;
+          }
 
-        _decodeAudioData(xhr.response);
-      }, onError: (e) {
-        // If there is an error, switch to HTML5 Audio.
-        if (_webAudio) {
-          _html5 = true;
-          _webAudio = false;
-          _sounds = [];
-          _cache.remove(url);
-          _loadImpl();
-        }
-      });
+          _decodeAudioData(xhr.response);
+        },
+        onError: (e) {
+          // If there is an error, switch to HTML5 Audio.
+          if (_webAudio) {
+            _html5 = true;
+            _webAudio = false;
+            _sounds = [];
+            _cache.remove(url);
+            _loadImpl();
+          }
+        },
+      );
     }
   }
 
@@ -2246,7 +2300,7 @@ class Howl {
     //var success = ;
 
     Howler.ctx!.decodeAudioData(arraybuffer).then((buffer) {
-      if (buffer != null && _sounds.isNotEmpty) {
+      if (_sounds.isNotEmpty) {
         _cache[_src] = buffer;
         _loadSound(buffer);
       } else {
@@ -2260,14 +2314,14 @@ class Howl {
   /// @param  {Object} buffer The decoded buffer sound source.
   void _loadSound(AudioBuffer buffer) {
     // Set the duration.
-    if (buffer != null && (_duration == null || _duration == 0)) {
+    if ((_duration == null || _duration == 0)) {
       _duration = buffer.duration as double?;
     }
 
     // Setup a sprite if none is defined.
     if (_sprite.isEmpty) {
       _sprite = {
-        '__default': _HowlSpriteParams(0, (_duration! * 1000).floor())
+        '__default': _HowlSpriteParams(0, (_duration! * 1000).floor()),
       };
     }
 
@@ -2416,8 +2470,11 @@ class Howl {
       } else {
         var sound = _soundById(id);
         if (sound != null && sound._node != null) {
-          sound._node!.eventTarget!
-              .removeEventListener('ended', endTimer, false);
+          sound._node!.eventTarget!.removeEventListener(
+            'ended',
+            endTimer,
+            false,
+          );
         }
       }
 
@@ -2532,8 +2589,10 @@ class Howl {
       sound._node!.bufferSource!.loopStart = sound._start;
       sound._node!.bufferSource!.loopEnd = sound._stop;
     }
-    sound._node!.bufferSource!.playbackRate!
-        .setValueAtTime(sound._rate!, Howler.ctx!.currentTime!);
+    sound._node!.bufferSource!.playbackRate!.setValueAtTime(
+      sound._rate!,
+      Howler.ctx!.currentTime!,
+    );
   }
 
   /// Prevent memory leaks by cleaning up the buffer source after playback.
@@ -2583,7 +2642,7 @@ class _HowlAudioNode {
 
   bool get isInfinityDuration {
     var duration = this.duration;
-    return duration != null && duration.isInfinite;
+    return duration.isInfinite;
   }
 
   void load() => audio!.load();
@@ -2708,11 +2767,10 @@ class Sound {
   void _errorListener(_) {
     // Fire an error event and pass back the code.
     _parent._emit(
-        'loaderror',
-        _id,
-        _node!.audio!.error != null
-            ? _node!.audio!.error!.code as String?
-            : '0');
+      'loaderror',
+      _id,
+      _node!.audio!.error != null ? _node!.audio!.error!.code as String? : '0',
+    );
 
     // Clear the event listener.
     _node!.eventTarget!.removeEventListener('error', _errorFn, false);
@@ -2728,7 +2786,7 @@ class Sound {
     // Setup a sprite if none is defined.
     if (parent._sprite.isEmpty) {
       parent._sprite = {
-        '__default': _HowlSpriteParams(0, (parent._duration! * 1000).floor())
+        '__default': _HowlSpriteParams(0, (parent._duration! * 1000).floor()),
       };
     }
 
@@ -2739,8 +2797,11 @@ class Sound {
     }
 
     // Clear the event listener.
-    _node!.eventTarget!
-        .removeEventListener(Howler._canPlayEvent, _loadFn, false);
+    _node!.eventTarget!.removeEventListener(
+      Howler._canPlayEvent,
+      _loadFn,
+      false,
+    );
   }
 
   Howl get parent => _parent;
@@ -2794,7 +2855,9 @@ void _setupAudioContext() {
   if (Howler.usingWebAudio) {
     Howler.masterGain = Howler.ctx!.createGain();
     Howler.masterGain.gain!.setValueAtTime(
-        Howler._muted ? 0 : Howler._volume, Howler.ctx!.currentTime!);
+      Howler._muted ? 0 : Howler._volume,
+      Howler.ctx!.currentTime!,
+    );
     Howler.masterGain.connectNode(Howler.ctx!.destination!);
   }
 

--- a/lib/src/howler_base.dart
+++ b/lib/src/howler_base.dart
@@ -17,7 +17,7 @@ import 'package:swiss_knife/swiss_knife.dart';
 
 typedef _SimpleCall = void Function();
 
-void _doCall(_SimpleCall call) {
+void _doCall(_SimpleCall? call) {
   if (call != null) {
     try {
       call();
@@ -51,7 +51,7 @@ class _DetectUserInteraction {
 
   static final List<_SimpleCall> _toCallOnDetection = [];
 
-  static List<StreamSubscription> _listeners;
+  static List<StreamSubscription>? _listeners;
 
   static void detect() {
     if (_listeners != null || _interactionDetected) return;
@@ -138,23 +138,23 @@ class _HowlerGlobal {
   double _volume = 1;
   final String _canPlayEvent = 'canplaythrough';
 
-  GainNode masterGain;
+  late GainNode masterGain;
   bool noAudio = false;
   bool usingWebAudio = true;
   bool autoSuspend = true;
-  AudioContext ctx;
-  String state;
+  AudioContext? ctx;
+  String? state;
 
   // Set to false to disable the auto audio unlocker.
   bool autoUnlock = true;
 
-  Navigator _navigator;
+  Navigator? _navigator;
 
-  String get userAgent => _navigator != null ? _navigator.userAgent : '';
+  String get userAgent => _navigator != null ? _navigator!.userAgent : '';
 
-  bool _ios;
+  bool? _ios;
 
-  bool get isIOS => _ios;
+  bool? get isIOS => _ios;
 
   _HowlerGlobal() {
     _navigator = window.navigator;
@@ -166,14 +166,14 @@ class _HowlerGlobal {
   }
 
   bool _calcIsIOS() {
-    return _navigator.vendor.contains('Apple') &&
-        RegExp(r'iP(?:hone|ad|od)').hasMatch(_navigator.platform);
+    return _navigator!.vendor.contains('Apple') &&
+        RegExp(r'iP(?:hone|ad|od)').hasMatch(_navigator!.platform!);
   }
 
   /// Get/set the global volume for all sounds.
   /// @param  {Float} vol Volume from 0.0 to 1.0.
   /// @return {Howler/Float}     Returns current volume.
-  double volume([double vol]) {
+  double volume([double? vol]) {
     // If we don't have an AudioContext created yet, run the setup.
     if (ctx == null) {
       _setupAudioContext();
@@ -189,7 +189,7 @@ class _HowlerGlobal {
 
       // When using Web Audio, we just need to adjust the master gain.
       if (usingWebAudio) {
-        masterGain.gain.setValueAtTime(vol, Howler.ctx.currentTime);
+        masterGain.gain!.setValueAtTime(vol, Howler.ctx!.currentTime!);
       }
 
       // Loop through and change volume for all HTML5 audio nodes.
@@ -203,7 +203,7 @@ class _HowlerGlobal {
             var sound = _howls[i]._soundById(ids[j]);
 
             if (sound != null && sound._node != null) {
-              sound._node.audio.volume = sound._volume * vol;
+              sound._node!.audio!.volume = sound._volume! * vol;
             }
           }
         }
@@ -225,8 +225,8 @@ class _HowlerGlobal {
 
     // With Web Audio, we just need to mute the master gain.
     if (usingWebAudio) {
-      masterGain.gain
-          .setValueAtTime(muted ? 0 : _volume, Howler.ctx.currentTime);
+      masterGain.gain!
+          .setValueAtTime(muted ? 0 : _volume, Howler.ctx!.currentTime!);
     }
 
     // Loop through and mute all HTML5 Audio nodes.
@@ -240,7 +240,7 @@ class _HowlerGlobal {
           var sound = _howls[i]._soundById(ids[j]);
 
           if (sound != null && sound._node != null) {
-            sound._node.audio.muted = (muted) ? true : sound._muted;
+            sound._node!.audio!.muted = (muted) ? true : sound._muted!;
           }
         }
       }
@@ -267,8 +267,8 @@ class _HowlerGlobal {
     }
 
     // Create a new AudioContext to make sure it is fully reset.
-    if (usingWebAudio && ctx != null && ctx.close != null) {
-      ctx.close();
+    if (usingWebAudio && ctx != null && ctx!.close != null) {
+      ctx!.close();
       ctx = null;
       _setupAudioContext();
     }
@@ -279,7 +279,7 @@ class _HowlerGlobal {
   /// Check for codec support of specific extension.
   /// @param  {String} ext Audio file extention.
   /// @return {bool}
-  bool codecs(String ext) {
+  bool? codecs(String ext) {
     ext = ext.replaceAll(RegExp('^x-'), '');
     return _codecs[ext];
   }
@@ -288,7 +288,7 @@ class _HowlerGlobal {
   /// @return {Howler}
   _HowlerGlobal _setup() {
     // Keeps track of the suspend/resume state of the AudioContext.
-    state = ctx != null ? ctx.state : null;
+    state = ctx != null ? ctx!.state : null;
     state ??= 'suspended';
 
     // Automatically begin the 30-second suspend process
@@ -375,7 +375,7 @@ class _HowlerGlobal {
 
   bool _audioUnlocked = false;
   bool _mobileUnloaded = false;
-  AudioBuffer _scratchBuffer;
+  AudioBuffer? _scratchBuffer;
 
   /// Some browsers/devices will only allow audio to be played after a user interaction.
   /// Attempt to automatically unlock audio on the first user interaction.
@@ -393,14 +393,14 @@ class _HowlerGlobal {
     // Some mobile devices/platforms have distortion issues when opening/closing tabs and/or web views.
     // Bugs in the browser (especially Mobile Safari) can cause the sampleRate to change from 44100 to 48000.
     // By calling Howler.unload(), we create a new AudioContext with the correct sampleRate.
-    if (!_mobileUnloaded && ctx.sampleRate != 44100) {
+    if (!_mobileUnloaded && ctx!.sampleRate != 44100) {
       _mobileUnloaded = true;
       unload();
     }
 
     // Scratch buffer for enabling iOS to dispose of web audio buffers correctly, as per:
     // http://stackoverflow.com/questions/24119684
-    _scratchBuffer = ctx.createBuffer(1, 1, 22050);
+    _scratchBuffer = ctx!.createBuffer(1, 1, 22050);
 
     // Setup a touch start listener to attempt an unlock in.
     document.addEventListener('touchstart', _unlock, true);
@@ -445,9 +445,9 @@ class _HowlerGlobal {
         for (var j = 0; j < ids.length; j++) {
           var sound = _howls[i]._soundById(ids[j]);
 
-          if (sound != null && sound._node != null && !sound._node._unlocked) {
-            sound._node._unlocked = true;
-            sound._node.audio.load();
+          if (sound != null && sound._node != null && !sound._node!._unlocked) {
+            sound._node!._unlocked = true;
+            sound._node!.audio!.load();
           }
         }
       }
@@ -457,15 +457,15 @@ class _HowlerGlobal {
     _autoResume();
 
     // Create an empty buffer.
-    var source = ctx.createBufferSource();
+    var source = ctx!.createBufferSource();
     source.buffer = _scratchBuffer;
-    source.connectNode(ctx.destination);
+    source.connectNode(ctx!.destination!);
 
     // Play the empty buffer.
     source.start(0);
 
     // Calling resume() on a stack initiated by user gesture is what actually unlocks the audio on Android Chrome >= 55.
-    ctx.resume();
+    ctx!.resume();
 
     // Setup a timeout to check that we are unlocked on the next event loop.
 
@@ -520,7 +520,7 @@ class _HowlerGlobal {
     return this;
   }
 
-  Timer _suspendTimer;
+  Timer? _suspendTimer;
   bool _resumeAfterSuspend = false;
 
   /// Automatically suspend the Web Audio AudioContext after no sound has played for 30 seconds.
@@ -535,7 +535,7 @@ class _HowlerGlobal {
     for (var i = 0; i < _howls.length; i++) {
       if (_howls[i]._webAudio) {
         for (var j = 0; j < _howls[i]._sounds.length; j++) {
-          if (!_howls[i]._sounds[j]._paused) {
+          if (!_howls[i]._sounds[j]._paused!) {
             return this;
           }
         }
@@ -543,7 +543,7 @@ class _HowlerGlobal {
     }
 
     if (_suspendTimer != null) {
-      _suspendTimer.cancel();
+      _suspendTimer!.cancel();
       _suspendTimer = null;
     }
 
@@ -563,7 +563,7 @@ class _HowlerGlobal {
         }
       };
 
-      ctx.suspend().then((_) {
+      ctx!.suspend().then((_) {
         handleSuspension();
       }, onError: (_) {
         handleSuspension();
@@ -581,13 +581,13 @@ class _HowlerGlobal {
     }
 
     if (state == 'running' &&
-        ctx.state != 'interrupted' &&
+        ctx!.state != 'interrupted' &&
         _suspendTimer != null) {
-      _suspendTimer.cancel();
+      _suspendTimer!.cancel();
       _suspendTimer = null;
     } else if (state == 'suspended' ||
-        state == 'running' && ctx.state == 'interrupted') {
-      ctx.resume().then((_) {
+        state == 'running' && ctx!.state == 'interrupted') {
+      ctx!.resume().then((_) {
         state = 'running';
 
         // Emit to all Howls that the audio has resumed.
@@ -597,7 +597,7 @@ class _HowlerGlobal {
       });
 
       if (_suspendTimer != null) {
-        _suspendTimer.cancel();
+        _suspendTimer!.cancel();
         _suspendTimer = null;
       }
     } else if (state == 'suspending') {
@@ -611,10 +611,10 @@ class _HowlerGlobal {
 final _HowlerGlobal Howler = _HowlerGlobal();
 
 typedef HowlEventListener = Function(
-    Howl howl, String eventType, int id, String message);
+    Howl howl, String eventType, int? id, String? message);
 
 class _HowlEventListenerWrapper {
-  final int id;
+  final int? id;
   final HowlEventListener function;
   final bool once;
 
@@ -622,7 +622,7 @@ class _HowlEventListenerWrapper {
 }
 
 class _HowlSrc {
-  List<String> _srcs;
+  List<String>? _srcs;
 
   _HowlSrc.value(String src) {
     _srcs = [src];
@@ -632,9 +632,9 @@ class _HowlSrc {
     _srcs ??= [];
   }
 
-  int get length => _srcs.length;
+  int get length => _srcs!.length;
 
-  String operator [](int index) => _srcs[index];
+  String operator [](int index) => _srcs![index];
 
   @override
   bool operator ==(Object other) =>
@@ -643,19 +643,19 @@ class _HowlSrc {
           runtimeType == other.runtimeType &&
           isEquivalentList(_srcs, other._srcs);
 
-  int _hashcode;
+  int? _hashcode;
 
   @override
   int get hashCode {
     if (_hashcode == null) {
       var h = 0;
-      for (var s in _srcs) {
+      for (var s in _srcs!) {
         h = h * 31 + s.hashCode;
       }
       _hashcode = h;
     }
 
-    return _hashcode;
+    return _hashcode!;
   }
 
   @override
@@ -665,9 +665,9 @@ class _HowlSrc {
 }
 
 class _HowlSpriteParams {
-  int from;
-  int to;
-  bool loop;
+  int? from;
+  int? to;
+  bool? loop;
 
   _HowlSpriteParams(this.from, this.to, [this.loop = false]);
 
@@ -705,46 +705,46 @@ class _HowlCall {
 }
 
 class Howl {
-  bool _autoplay;
-  List<String> _format;
-  bool _html5;
-  bool _muted;
-  bool _loop;
-  int _pool;
-  bool _preload;
-  double _rate;
-  Map<String, _HowlSpriteParams> _sprite;
-  _HowlSrc _src;
-  double _volume;
+  late bool _autoplay;
+  List<String>? _format;
+  late bool _html5;
+  bool? _muted;
+  bool? _loop;
+  late int _pool;
+  late bool _preload;
+  double? _rate;
+  late Map<String, _HowlSpriteParams> _sprite;
+  _HowlSrc? _src;
+  double? _volume;
 
-  String _xhrMethod;
-  bool _xhrWithCredentials;
-  Map<String, String> _xhrHeaders;
+  String? _xhrMethod;
+  bool? _xhrWithCredentials;
+  Map<String, String>? _xhrHeaders;
 
-  double _duration;
-  String _state;
-  List<Sound> _sounds;
-  Map<int, dynamic> _endTimers;
-  List<_HowlCall> _queue;
-  bool _playLock;
+  double? _duration;
+  String? _state;
+  late List<Sound> _sounds;
+  late Map<int?, dynamic> _endTimers;
+  late List<_HowlCall> _queue;
+  late bool _playLock;
 
   // Setup event listeners.
-  List<_HowlEventListenerWrapper> _onend;
-  List<_HowlEventListenerWrapper> _onfade;
-  List<_HowlEventListenerWrapper> _onload;
-  List<_HowlEventListenerWrapper> _onloaderror;
-  List<_HowlEventListenerWrapper> _onplayerror;
-  List<_HowlEventListenerWrapper> _onpause;
-  List<_HowlEventListenerWrapper> _onplay;
-  List<_HowlEventListenerWrapper> _onstop;
-  List<_HowlEventListenerWrapper> _onmute;
-  List<_HowlEventListenerWrapper> _onvolume;
-  List<_HowlEventListenerWrapper> _onrate;
-  List<_HowlEventListenerWrapper> _onseek;
-  List<_HowlEventListenerWrapper> _onunlock;
-  List<_HowlEventListenerWrapper> _onresume;
+  List<_HowlEventListenerWrapper>? _onend;
+  List<_HowlEventListenerWrapper>? _onfade;
+  List<_HowlEventListenerWrapper>? _onload;
+  List<_HowlEventListenerWrapper>? _onloaderror;
+  List<_HowlEventListenerWrapper>? _onplayerror;
+  List<_HowlEventListenerWrapper>? _onpause;
+  List<_HowlEventListenerWrapper>? _onplay;
+  List<_HowlEventListenerWrapper>? _onstop;
+  List<_HowlEventListenerWrapper>? _onmute;
+  List<_HowlEventListenerWrapper>? _onvolume;
+  List<_HowlEventListenerWrapper>? _onrate;
+  List<_HowlEventListenerWrapper>? _onseek;
+  List<_HowlEventListenerWrapper>? _onunlock;
+  List<_HowlEventListenerWrapper>? _onresume;
 
-  List<_HowlEventListenerWrapper> _getEventListeners(String eventType) {
+  List<_HowlEventListenerWrapper>? _getEventListeners(String eventType) {
     switch (eventType) {
       case 'end':
         return _onend;
@@ -779,37 +779,37 @@ class Howl {
     }
   }
 
-  bool _webAudio;
+  late bool _webAudio;
 
   Howl(
-      {List<String> src,
+      {List<String>? src,
       bool autoplay = false,
-      List<String> format,
+      List<String>? format,
       bool html5 = false,
       bool mute = false,
       bool loop = false,
       int pool = 5,
       bool preload = true,
       double rate = 1,
-      Map<String, List> sprite,
+      Map<String, List>? sprite,
       double volume = 1,
       String xhrMethod = 'GET',
       bool xhrWithCredentials = false,
-      Map<String, String> xhrHeaders,
-      HowlEventListener onend,
-      HowlEventListener onfade,
-      HowlEventListener onload,
-      HowlEventListener onloaderror,
-      HowlEventListener onplayerror,
-      HowlEventListener onpause,
-      HowlEventListener onplay,
-      HowlEventListener onstop,
-      HowlEventListener onmute,
-      HowlEventListener onvolume,
-      HowlEventListener onrate,
-      HowlEventListener onseek,
-      HowlEventListener onunlock,
-      HowlEventListener onresume}) {
+      Map<String, String>? xhrHeaders,
+      HowlEventListener? onend,
+      HowlEventListener? onfade,
+      HowlEventListener? onload,
+      HowlEventListener? onloaderror,
+      HowlEventListener? onplayerror,
+      HowlEventListener? onpause,
+      HowlEventListener? onplay,
+      HowlEventListener? onstop,
+      HowlEventListener? onmute,
+      HowlEventListener? onvolume,
+      HowlEventListener? onrate,
+      HowlEventListener? onseek,
+      HowlEventListener? onunlock,
+      HowlEventListener? onresume}) {
     _DetectUserInteraction.detect();
 
     if (src == null || src.isEmpty) {
@@ -900,7 +900,7 @@ class Howl {
 
   /// Calls [load] than [play] and [callback] when load event happens.
   /// If [this] is already loaded, [play] and [callback] are called immediately.
-  Howl loadAndPlay({dynamic sprite, bool safe = true, _SimpleCall callback}) {
+  Howl loadAndPlay({dynamic sprite, bool safe = true, _SimpleCall? callback}) {
     safe ??= true;
 
     if (isLoaded) {
@@ -934,7 +934,7 @@ class Howl {
   ///
   /// [callback] Optional callback for when the 'load' event happens. If this is already loaded, it's called immediately.
   /// @return {Howler}
-  Howl load([_SimpleCall callback]) {
+  Howl load([_SimpleCall? callback]) {
     if (callback == null) {
       _loadImpl();
     } else if (isLoaded) {
@@ -951,7 +951,7 @@ class Howl {
   }
 
   void _loadImpl() {
-    String url;
+    String? url;
 
     // If no audio is available, quit immediately.
     if (Howler.noAudio) {
@@ -960,15 +960,15 @@ class Howl {
     }
 
     // Loop through the sources and pick the first one that is compatible.
-    for (var i = 0; i < _src.length; i++) {
-      String ext, src;
+    for (var i = 0; i < _src!.length; i++) {
+      String? ext, src;
 
-      if (_format != null && i < _format.length && _format[i] != null) {
+      if (_format != null && i < _format!.length && _format![i] != null) {
         // If an extension was specified, use that instead.
-        ext = _format[i];
+        ext = _format![i];
       } else {
         // Make sure the source is a string.
-        src = _src[i];
+        src = _src![i];
         if (src == null) {
           _emit('loaderror', null,
               'Non-string found in selected audio sources - ignoring.');
@@ -997,8 +997,8 @@ class Howl {
       }
 
       // Check if this extension is available.
-      if (ext != null && Howler.codecs(ext)) {
-        url = _src[i];
+      if (ext != null && Howler.codecs(ext)!) {
+        url = _src![i];
         break;
       }
     }
@@ -1048,7 +1048,8 @@ class Howl {
   ///
   /// If user hasn't interacted yet, this call will be put in a queue to be
   /// flushed when interaction is detected.
-  int playSafe({dynamic sprite, bool internal = false, _SimpleCall callback}) {
+  int? playSafe(
+      {dynamic sprite, bool internal = false, _SimpleCall? callback}) {
     if (userInitialInteractionDetected) {
       var id = play(sprite, internal);
       _doCall(callback);
@@ -1066,8 +1067,8 @@ class Howl {
   /// @param  {String/Number} sprite   Sprite name for sprite playback or sound id to continue previous.
   /// @param  {Boolean} internal Internal Use: true prevents event firing.
   /// @return {Number}          Sound ID.
-  int play([dynamic sprite, bool internal = false]) {
-    int id;
+  int? play([dynamic sprite, bool internal = false]) {
+    int? id;
 
     if (sprite == null) {
       // Use the default sound sprite (plays the full audio length).
@@ -1078,7 +1079,7 @@ class Howl {
       if (!_playLock) {
         var num = 0;
         for (var i = 0; i < _sounds.length; i++) {
-          if (_sounds[i]._paused && !_sounds[i]._ended) {
+          if (_sounds[i]._paused! && !_sounds[i]._ended!) {
             num++;
             id = _sounds[i]._id;
           }
@@ -1137,7 +1138,7 @@ class Howl {
     }
 
     // Don't play the sound if an id was passed and it is already playing.
-    if (id != null && !sound._paused) {
+    if (id != null && !sound._paused!) {
       // Trigger the play event, in order to keep iterating through queue.
       if (!internal) {
         _loadQueue('play');
@@ -1153,13 +1154,13 @@ class Howl {
 
     // Determine how long to play for and where to start playing.
     var seek = Math.max(
-        0, sound._seek > 0 ? sound._seek : _sprite[sprite].from / 1000);
+        0, sound._seek! > 0 ? sound._seek! : _sprite[sprite]!.from! / 1000);
     var duration = Math.max(
-        0, ((_sprite[sprite].from + _sprite[sprite].to) / 1000) - seek);
-    var timeout = (duration * 1000) ~/ sound._rate.abs();
+        0, ((_sprite[sprite]!.from! + _sprite[sprite]!.to!) / 1000) - seek);
+    var timeout = (duration * 1000) ~/ sound._rate!.abs();
 
-    var start = _sprite[sprite].from / 1000;
-    var stop = (_sprite[sprite].from + _sprite[sprite].to) / 1000;
+    var start = _sprite[sprite]!.from! / 1000;
+    var stop = (_sprite[sprite]!.from! + _sprite[sprite]!.to!) / 1000;
 
     sound._sprite = sprite;
 
@@ -1170,14 +1171,14 @@ class Howl {
     // Update the parameters of the sound.
     var setParams = () {
       sound._paused = false;
-      sound._seek = seek;
+      sound._seek = seek as double?;
       sound._start = start;
       sound._stop = stop;
 
-      var loop = sound._loop;
+      var loop = sound._loop!;
       if (!loop) {
-        var spriteConf = _sprite[sprite];
-        loop = spriteConf.loop;
+        var spriteConf = _sprite[sprite]!;
+        loop = spriteConf.loop!;
       }
 
       sound._loop = loop;
@@ -1200,13 +1201,13 @@ class Howl {
         _refreshBuffer(sound);
 
         // Setup the playback params.
-        var vol = (sound._muted || _muted) ? 0 : sound._volume;
-        node.gainNode.gain.setValueAtTime(vol, Howler.ctx.currentTime);
-        sound._playStart = Howler.ctx.currentTime;
+        var vol = (sound._muted! || _muted!) ? 0 : sound._volume!;
+        node!.gainNode!.gain!.setValueAtTime(vol, Howler.ctx!.currentTime!);
+        sound._playStart = Howler.ctx!.currentTime as double?;
 
-        sound._loop
-            ? node.bufferSource.start(0, seek, 86400)
-            : node.bufferSource.start(0, seek, duration);
+        sound._loop!
+            ? node.bufferSource!.start(0, seek, 86400)
+            : node.bufferSource!.start(0, seek, duration);
 
         // Start a new timer if none is present.
         if (timeout > 0 && timeout < 100000000) {
@@ -1222,7 +1223,7 @@ class Howl {
         }
       };
 
-      if (Howler.state == 'running' && Howler.ctx.state != 'interrupted') {
+      if (Howler.state == 'running' && Howler.ctx!.state != 'interrupted') {
         playWebAudio(this, 'play', sound._id, null);
       } else {
         _playLock = true;
@@ -1236,15 +1237,15 @@ class Howl {
     } else {
       // Fire this when the sound is ready to play to begin HTML5 Audio playback.
       var playHtml5 = () {
-        node.audio.currentTime = seek;
-        node.audio.muted =
-            sound._muted || _muted || Howler._muted || node.audio.muted;
-        node.audio.volume = sound._volume * Howler.volume();
-        node.audio.playbackRate = sound._rate;
+        node!.audio!.currentTime = seek;
+        node.audio!.muted =
+            sound._muted! || _muted! || Howler._muted || node.audio!.muted;
+        node.audio!.volume = sound._volume! * Howler.volume();
+        node.audio!.playbackRate = sound._rate!;
 
         // Some browsers will throw an error if this is called without user interaction.
         try {
-          var play = node.audio.play();
+          var play = node.audio!.play();
 
           if (play != null) {
             // Implements a lock to prevent DOMException: The play() request was interrupted by a call to pause().
@@ -1282,10 +1283,10 @@ class Howl {
           }
 
           // Setting rate before playing won't work in IE, so we set it again here.
-          node.audio.playbackRate = sound._rate;
+          node.audio!.playbackRate = sound._rate!;
 
           // If the node is still paused, then we can assume there was a playback issue.
-          if (node.audio.paused) {
+          if (node.audio!.paused) {
             _emit(
                 'playerror',
                 sound._id,
@@ -1295,7 +1296,7 @@ class Howl {
           }
 
           // Setup the end timer on sprites or listen for the ended event.
-          if (sprite != '__default' || sound._loop) {
+          if (sprite != '__default' || sound._loop!) {
             _endTimers[sound._id] = Timer(Duration(milliseconds: timeout), () {
               _ended(sound);
             });
@@ -1308,23 +1309,23 @@ class Howl {
               _clearTimer(sound._id);
             };
 
-            node.eventTarget
+            node.eventTarget!
                 .addEventListener('ended', _endTimers[sound._id], false);
           }
         } catch (err) {
-          _emit('playerror', sound._id, err);
+          _emit('playerror', sound._id, err.toString());
         }
       };
 
       // If this is streaming audio, make sure the src is set and load again.
-      if (node.src ==
+      if (node!.src ==
           'data:audio/wav;base64,UklGRigAAABXQVZFZm10IBIAAAABAAEARKwAAIhYAQACABAAAABkYXRhAgAAAAEA') {
-        node.src = _src[0];
+        node.src = _src![0];
         node.load();
       }
 
       // Play immediately if ready, or wait for the 'canplaythrough'e vent.
-      if (node.audio.readyState >= 3) {
+      if (node.audio!.readyState >= 3) {
         playHtml5();
       } else {
         _playLock = true;
@@ -1340,7 +1341,7 @@ class Howl {
           _clearTimer(sound._id);
         };
 
-        node.eventTarget
+        node.eventTarget!
             .addEventListener(Howler._canPlayEvent, listener, false);
       }
     }
@@ -1352,7 +1353,7 @@ class Howl {
   ///
   /// If [this] is currently [playing], it will [pause] the sound,
   /// otherwise it will [play].
-  bool playOrPauseSwitch([int id]) {
+  bool playOrPauseSwitch([int? id]) {
     if (playing(id)) {
       pause();
       return false;
@@ -1365,7 +1366,7 @@ class Howl {
   /// Pause playback and save current position.
   /// @param  {Number} id The sound ID (empty to pause all in group).
   /// @return {Howl}
-  Howl pause([int id, bool internal = false]) {
+  Howl pause([int? id, bool internal = false]) {
     // If the sound hasn't loaded or a play() promise is pending, add it to the load queue to pause when capable.
     if (_state != 'loaded' || _playLock) {
       _queue.add(_HowlCall('pause', () => pause(id)));
@@ -1382,7 +1383,7 @@ class Howl {
       // Get the sound.
       var sound = _soundById(id2);
 
-      if (sound != null && !sound._paused) {
+      if (sound != null && !sound._paused!) {
         // Reset the seek position.
         sound._seek = getSeek(id2);
         sound._rateSeek = 0;
@@ -1394,17 +1395,17 @@ class Howl {
         if (sound._node != null) {
           if (_webAudio) {
             // Make sure the sound has been created.
-            if (sound._node.bufferSource == null) {
+            if (sound._node!.bufferSource == null) {
               continue;
             }
 
-            sound._node.bufferSource.stop(0);
+            sound._node!.bufferSource!.stop(0);
 
             // Clean up the buffer source.
-            _cleanBuffer(sound._node);
-          } else if (!sound._node.audio.duration.isNaN ||
-              sound._node.audio.duration.isInfinite) {
-            sound._node.audio.pause();
+            _cleanBuffer(sound._node!);
+          } else if (!sound._node!.audio!.duration.isNaN ||
+              sound._node!.audio!.duration.isInfinite) {
+            sound._node!.audio!.pause();
           }
         }
       }
@@ -1434,7 +1435,7 @@ class Howl {
   /// @param  {Number} id The sound ID (empty to stop all in group).
   /// @param  {Boolean} internal Internal Use: true prevents event firing.
   /// @return {Howl}
-  Howl stop(int id, [bool internal = false]) {
+  Howl stop(int? id, [bool internal = false]) {
     // If the sound hasn't loaded, add it to the load queue to stop when capable.
     if (_state != 'loaded' || _playLock) {
       _queue.add(_HowlCall('stop', () => stop(id)));
@@ -1464,19 +1465,19 @@ class Howl {
         if (sound._node != null) {
           if (_webAudio) {
             // Make sure the sound's AudioBufferSourceNode has been created.
-            if (sound._node.bufferSource != null) {
-              sound._node.bufferSource.stop(0);
+            if (sound._node!.bufferSource != null) {
+              sound._node!.bufferSource!.stop(0);
 
               // Clean up the buffer source.
-              _cleanBuffer(sound._node);
+              _cleanBuffer(sound._node!);
             }
-          } else if (!sound._node.audio.duration.isNaN ||
-              sound._node.audio.duration.isInfinite) {
-            sound._node.audio.currentTime = sound._start;
-            sound._node.audio.pause();
+          } else if (!sound._node!.audio!.duration.isNaN ||
+              sound._node!.audio!.duration.isInfinite) {
+            sound._node!.audio!.currentTime = sound._start;
+            sound._node!.audio!.pause();
 
             // If this is a live stream, stop download once the audio is stopped.
-            if (sound._node.isInfinityDuration) {
+            if (sound._node!.isInfinityDuration) {
               _clearSound(sound._node);
             }
           }
@@ -1495,7 +1496,7 @@ class Howl {
   /// @param  {Boolean} muted Set to true to mute and false to unmute.
   /// @param  {Number} id    The sound ID to update (omit to mute/unmute all).
   /// @return {Howl}
-  Howl mute(bool muted, [int id]) {
+  Howl mute(bool muted, [int? id]) {
     // If the sound hasn't loaded, add it to the load queue to mute when capable.
     if (_state != 'loaded' || _playLock) {
       _queue.add(_HowlCall('mute', () => mute(muted, id)));
@@ -1528,10 +1529,10 @@ class Howl {
         }
 
         if (_webAudio && sound._node != null) {
-          sound._node.gainNode.gain.setValueAtTime(
-              muted ? 0 : sound._volume, Howler.ctx.currentTime);
+          sound._node!.gainNode!.gain!.setValueAtTime(
+              muted ? 0 : sound._volume!, Howler.ctx!.currentTime!);
         } else if (sound._node != null) {
-          sound._node.audio.muted = Howler._muted ? true : muted;
+          sound._node!.audio!.muted = Howler._muted ? true : muted;
         }
 
         _emit('mute', sound._id);
@@ -1545,7 +1546,7 @@ class Howl {
   ///   getVolume() -> Returns the group's volume value.
   ///   getVolume(id) -> Returns the sound id's current volume.
   /// @return {double} Returns current volume.
-  double getVolume([int id]) {
+  double? getVolume([int? id]) {
     // Determine the values based on arguments.
     if (id == null) {
       // Return the value of the groups' volume.
@@ -1562,7 +1563,7 @@ class Howl {
   ///   volume(vol) -> Sets the volume of all sounds in this Howl group.
   ///   volume(vol, id) -> Sets the volume of passed sound id.
   /// @return {Howl} Returns this.
-  Howl setVolume(double vol, [int id, bool internal = false]) {
+  Howl setVolume(double? vol, [int? id, bool internal = false]) {
     if (vol == null || vol < 0 || vol > 1) return this;
 
     // If the sound hasn't loaded, add it to the load queue to change volume when capable.
@@ -1591,10 +1592,11 @@ class Howl {
           _stopFade(id2);
         }
 
-        if (_webAudio && sound._node != null && !sound._muted) {
-          sound._node.gainNode.gain.setValueAtTime(vol, Howler.ctx.currentTime);
-        } else if (sound._node != null && !sound._muted) {
-          sound._node.audio.volume = vol * Howler.volume();
+        if (_webAudio && sound._node != null && !sound._muted!) {
+          sound._node!.gainNode!.gain!
+              .setValueAtTime(vol, Howler.ctx!.currentTime!);
+        } else if (sound._node != null && !sound._muted!) {
+          sound._node!.audio!.volume = vol * Howler.volume();
         }
 
         _emit('volume', sound._id);
@@ -1609,7 +1611,7 @@ class Howl {
   /// If user hasn't interacted yet, this call will be put in a queue to be
   /// flushed when interaction is detected.
   Howl fadeSafe(double from, double to, int len,
-      {int id, _SimpleCall callback}) {
+      {int? id, _SimpleCall? callback}) {
     if (userInitialInteractionDetected) {
       fade(from, to, len, id);
       _doCall(callback);
@@ -1628,7 +1630,7 @@ class Howl {
   /// @param  {Number} len  Time in milliseconds to fade.
   /// @param  {Number} id   The sound id (omit to fade all sounds).
   /// @return {Howl}
-  Howl fade(double from, double to, int len, [int id]) {
+  Howl fade(double from, double to, int len, [int? id]) {
     // If the sound hasn't loaded, add it to the load queue to fade when capable.
     if (_state != 'loaded' || _playLock) {
       _queue.add(_HowlCall('fade', () => fade(from, to, len, id)));
@@ -1656,12 +1658,12 @@ class Howl {
         }
 
         // If we are using Web Audio, let the native methods do the actual fade.
-        if (_webAudio && !sound._muted) {
-          var currentTime = Howler.ctx.currentTime;
-          var end = currentTime + (len / 1000);
+        if (_webAudio && !sound._muted!) {
+          var currentTime = Howler.ctx!.currentTime!;
+          num end = currentTime + (len / 1000);
           sound._volume = from;
-          sound._node.gainNode.gain.setValueAtTime(from, currentTime);
-          sound._node.gainNode.gain.linearRampToValueAtTime(to, end);
+          sound._node!.gainNode!.gain!.setValueAtTime(from, currentTime);
+          sound._node!.gainNode!.gain!.linearRampToValueAtTime(to, end);
         }
 
         _startFadeInterval(sound, from, to, len, ids[i], id == null);
@@ -1734,7 +1736,7 @@ class Howl {
       // When the fade is complete, stop it and fire event.
       if ((to < from && vol <= to) || (to > from && vol >= to)) {
         if (sound._interval != null) {
-          sound._interval.cancel();
+          sound._interval!.cancel();
           sound._interval = null;
         }
 
@@ -1750,15 +1752,16 @@ class Howl {
   /// a new fade starts, volume is changed or the sound is stopped.
   /// @param  {Number} id The sound id.
   /// @return {Howl}
-  void _stopFade(int id) {
+  void _stopFade(int? id) {
     var sound = _soundById(id);
 
     if (sound != null && sound._interval != null) {
       if (_webAudio) {
-        sound._node.gainNode.gain.cancelScheduledValues(Howler.ctx.currentTime);
+        sound._node!.gainNode!.gain!
+            .cancelScheduledValues(Howler.ctx!.currentTime!);
       }
 
-      sound._interval.cancel();
+      sound._interval!.cancel();
       sound._interval = null;
 
       setVolume(sound._fadeTo, id);
@@ -1772,7 +1775,7 @@ class Howl {
   ///   getLoop() -> Returns the group's loop value.
   ///   getLoop(id) -> Returns the sound id's loop value.
   /// @return {Boolean} Returns current loop value.
-  bool getLoop([int id]) {
+  bool? getLoop([int? id]) {
     // Determine the values for loop and id.
     if (id == null) {
       // Return the grou's loop value.
@@ -1787,7 +1790,7 @@ class Howl {
   ///   setLoop(loop) -> Sets the loop value for all sounds in this Howl group.
   ///   setLoop(loop, id) -> Sets the loop value of passed sound id.
   /// @return {Howl} Returns this.
-  Howl setLoop(bool loop, [int id]) {
+  Howl setLoop(bool loop, [int? id]) {
     if (id == null) {
       _loop = loop;
     }
@@ -1803,12 +1806,12 @@ class Howl {
 
         if (_webAudio &&
             sound._node != null &&
-            sound._node.bufferSource != null) {
-          sound._node.bufferSource.loop = loop;
+            sound._node!.bufferSource != null) {
+          sound._node!.bufferSource!.loop = loop;
 
           if (loop) {
-            sound._node.bufferSource.loopStart = sound._start;
-            sound._node.bufferSource.loopEnd = sound._stop;
+            sound._node!.bufferSource!.loopStart = sound._start;
+            sound._node!.bufferSource!.loopEnd = sound._stop;
           }
         }
       }
@@ -1821,7 +1824,7 @@ class Howl {
   ///   getRate() -> Returns the first sound node's current playback rate.
   ///   getRate(id) -> Returns the sound id's current playback rate.
   /// @return {double} Returns the current playback rate.
-  double getRate([int id]) {
+  double? getRate([int? id]) {
     // Determine the values based on arguments.
     // We will simply return the current rate of the first node.
     id ??= _sounds[0]._id;
@@ -1834,7 +1837,7 @@ class Howl {
   ///   setRate(rate) -> Sets the playback rate of all sounds in this Howl group.
   ///   setRate(rate, id) -> Sets the playback rate of passed sound id.
   /// @return {Howl} Returns this.
-  Howl setRate(double rate, [int id]) {
+  Howl setRate(double rate, [int? id]) {
     // If the sound hasn't loaded, add it to the load queue to change playback rate when capable.
     if (_state != 'loaded' || _playLock) {
       _queue.add(_HowlCall('rate', () => setRate(rate, id)));
@@ -1860,29 +1863,30 @@ class Howl {
         if (playing(id2)) {
           sound._rateSeek = getSeek(id2);
           sound._playStart =
-              _webAudio ? Howler.ctx.currentTime : sound._playStart;
+              _webAudio ? Howler.ctx!.currentTime as double? : sound._playStart;
         }
         sound._rate = rate;
 
         // Change the playback rate.
         if (_webAudio &&
             sound._node != null &&
-            sound._node.bufferSource != null) {
-          sound._node.bufferSource.playbackRate
-              .setValueAtTime(rate, Howler.ctx.currentTime);
+            sound._node!.bufferSource != null) {
+          sound._node!.bufferSource!.playbackRate!
+              .setValueAtTime(rate, Howler.ctx!.currentTime!);
         } else if (sound._node != null) {
-          sound._node.audio.playbackRate = rate;
+          sound._node!.audio!.playbackRate = rate;
         }
 
         // Reset the timers.
-        var seek = getSeek(id2);
+        var seek = getSeek(id2)!;
         var duration =
-            ((_sprite[sound._sprite].from + _sprite[sound._sprite].to) / 1000) -
+            ((_sprite[sound._sprite]!.from! + _sprite[sound._sprite]!.to!) /
+                    1000) -
                 seek;
-        var timeout = (duration * 1000) ~/ sound._rate.abs();
+        var timeout = (duration * 1000) ~/ sound._rate!.abs();
 
         // Start a new end timer if sound is already playing.
-        if (_endTimers[id2] != null || !sound._paused) {
+        if (_endTimers[id2] != null || !sound._paused!) {
           _clearTimer(id2);
 
           Timer(Duration(milliseconds: timeout), () {
@@ -1901,7 +1905,7 @@ class Howl {
   ///   getSeek() -> Returns the first sound node's current seek position.
   ///   getSeek(id) -> Returns the sound id's current seek position.
   /// @return {double} Returns the current seek position.
-  double getSeek([int id]) {
+  double? getSeek([int? id]) {
     // Determine the values based on arguments.
     // We will simply return the current position of the first node.
     id ??= _sounds[0]._id;
@@ -1920,13 +1924,13 @@ class Howl {
     if (sound != null) {
       if (_webAudio) {
         double realTime =
-            playing(id) ? Howler.ctx.currentTime - sound._playStart : 0;
-        var rateSeek = sound._rateSeek != null && sound._rateSeek > 0
-            ? sound._rateSeek - sound._seek
+            playing(id) ? Howler.ctx!.currentTime! - sound._playStart! : 0;
+        var rateSeek = sound._rateSeek != null && sound._rateSeek! > 0
+            ? sound._rateSeek! - sound._seek!
             : 0;
-        return sound._seek + (rateSeek + realTime * sound._rate.abs());
+        return sound._seek! + (rateSeek + realTime * sound._rate!.abs());
       } else {
-        return sound._node.audio.currentTime;
+        return sound._node!.audio!.currentTime as double?;
       }
     }
 
@@ -1937,7 +1941,7 @@ class Howl {
   ///   setSeek(seek) -> Sets the seek position of the first sound node.
   ///   setSeek(seek, id) -> Sets the seek position of passed sound id.
   /// @return {Howl} Returns this.
-  Howl setSeek(double seek, [int id]) {
+  Howl setSeek(double seek, [int? id]) {
     // Determine the values based on arguments.
     id ??= _sounds[0]._id;
 
@@ -1968,8 +1972,8 @@ class Howl {
       // Update the seek position for HTML5 Audio.
       if (!_webAudio &&
           sound._node != null &&
-          !sound._node.audio.duration.isNaN) {
-        sound._node.audio.currentTime = seek;
+          !sound._node!.audio!.duration.isNaN) {
+        sound._node!.audio!.currentTime = seek;
       }
 
       // Seek and emit when ready.
@@ -2001,16 +2005,16 @@ class Howl {
   /// Check if a specific sound is currently playing or not (if id is provided), or check if at least one of the sounds in the group is playing or not.
   /// @param  {Number}  id The sound id to check. If none is passed, the whole sound group is checked.
   /// @return {Boolean} True if playing and false if not.
-  bool playing([int id]) {
+  bool playing([int? id]) {
     // Check the passed sound ID (if any).
     if (id != null) {
       var sound = _soundById(id);
-      return sound != null ? !sound._paused : false;
+      return sound != null ? !sound._paused! : false;
     }
 
     // Otherwise, loop through all sounds and check if any are playing.
     for (var i = 0; i < _sounds.length; i++) {
-      if (!_sounds[i]._paused) {
+      if (!_sounds[i]._paused!) {
         return true;
       }
     }
@@ -2021,7 +2025,7 @@ class Howl {
   /// Get the duration of this sound. Passing a sound id will return the sprite duration.
   /// @param  {Number} id The sound id to check. If none is passed, return full source duration.
   /// @return {Number} Audio duration in seconds.
-  double duration([int id]) {
+  double? duration([int? id]) {
     if (id == null) {
       return _duration;
     }
@@ -2030,7 +2034,7 @@ class Howl {
     var sound = _soundById(id);
 
     if (sound != null) {
-      return _sprite[sound._sprite].to / 1000;
+      return _sprite[sound._sprite]!.to! / 1000;
     } else {
       return _duration;
     }
@@ -2038,7 +2042,7 @@ class Howl {
 
   /// Returns the current loaded state of this Howl.
   /// @return {String} 'unloaded', 'loading', 'loaded'
-  String state() => _state;
+  String? state() => _state;
 
   /// Unload and destroy the current Howl object.
   /// This will immediately stop all sound instances attached to this group.
@@ -2049,7 +2053,7 @@ class Howl {
     for (var i = 0; i < sounds.length; i++) {
       var sound = sounds[i];
       // Stop the sound if it is currently playing.
-      if (!sound._paused) {
+      if (!sound._paused!) {
         stop(sound._id);
       }
 
@@ -2058,13 +2062,13 @@ class Howl {
         _clearSound(sounds[i]._node);
 
         // Remove any event listeners.
-        sound._node.eventTarget
+        sound._node!.eventTarget!
             .removeEventListener('error', sound._errorFn, false);
-        sound._node.eventTarget
+        sound._node!.eventTarget!
             .removeEventListener(Howler._canPlayEvent, sound._loadFn, false);
 
         // Release the Audio object back to the pool.
-        Howler._releaseHtml5Audio(sound._node);
+        Howler._releaseHtml5Audio(sound._node!);
       }
 
       // Empty out all of the nodes.
@@ -2111,8 +2115,8 @@ class Howl {
   /// @param  {Number}   once  (INTERNAL) Marks event to fire only once.
   /// @return {Howl}
   Howl on(String eventType, HowlEventListener function,
-      [int id, bool once = false]) {
-    var events = _getEventListeners(eventType);
+      [int? id, bool once = false]) {
+    var events = _getEventListeners(eventType)!;
     var listener = _HowlEventListenerWrapper(function, id, once);
     events.add(listener);
     return this;
@@ -2123,13 +2127,13 @@ class Howl {
   /// @param  {Function} fn    Listener to remove. Leave empty to remove all.
   /// @param  {Number}   id    (optional) Only remove events for this sound.
   /// @return {Howl}
-  Howl off(String eventType, [int id, HowlEventListener function]) {
+  Howl off(String eventType, [int? id, HowlEventListener? function]) {
     var events = _getEventListeners(eventType);
     var i = 0;
 
     if (id != null) {
       // Loop through event store and remove the passed function.
-      for (i = 0; i < events.length; i++) {
+      for (i = 0; i < events!.length; i++) {
         var isId = (id == events[i].id);
 
         if (isId && (function == null || function == events[i].function)) {
@@ -2139,27 +2143,27 @@ class Howl {
       }
     } else {
       // Clear out all events of this type.
-      events.clear();
+      events!.clear();
     }
 
     return this;
   }
 
   Howl offAll() {
-    _onend.clear();
-    _onfade.clear();
-    _onload.clear();
-    _onloaderror.clear();
-    _onplayerror.clear();
-    _onpause.clear();
-    _onplay.clear();
-    _onstop.clear();
-    _onmute.clear();
-    _onvolume.clear();
-    _onrate.clear();
-    _onseek.clear();
-    _onunlock.clear();
-    _onresume.clear();
+    _onend!.clear();
+    _onfade!.clear();
+    _onload!.clear();
+    _onloaderror!.clear();
+    _onplayerror!.clear();
+    _onpause!.clear();
+    _onplay!.clear();
+    _onstop!.clear();
+    _onmute!.clear();
+    _onvolume!.clear();
+    _onrate!.clear();
+    _onseek!.clear();
+    _onunlock!.clear();
+    _onresume!.clear();
 
     return this;
   }
@@ -2169,24 +2173,24 @@ class Howl {
   /// @param  {Function} fn    Listener to call.
   /// @param  {Number}   id    (optional) Only listen to events for this sound.
   /// @return {Howl}
-  Howl once(String event, HowlEventListener function, [int id]) {
+  Howl once(String event, HowlEventListener function, [int? id]) {
     on(event, function, id, true);
     return this;
   }
 
-  final Map<_HowlSrc, AudioBuffer> _cache = {};
+  final Map<_HowlSrc?, AudioBuffer> _cache = {};
 
   /// Buffer a sound from URL, Data URI or cache and decode to audio source (Web Audio API).
   /// @param  {Howl} this
   void _loadBuffer() {
-    var url = _src[0];
+    var url = _src![0];
 
     // Check if the buffer has already been cached and use it instead.
     var audioBuffer = _cache[url];
 
     if (audioBuffer != null) {
       // Set the duration from the cache.
-      _duration = audioBuffer.duration;
+      _duration = audioBuffer.duration as double?;
 
       // Load the sound into this Howl.
       _loadSound(audioBuffer);
@@ -2208,7 +2212,7 @@ class Howl {
         responseType: 'arraybuffer',
       ).then((xhr) {
         // Make sure we get a successful response back.
-        var code = xhr.status;
+        var code = xhr.status!;
         if (code < 200 || code >= 400) {
           _emit('loaderror', null,
               'Failed loading audio file with status: $code');
@@ -2241,7 +2245,7 @@ class Howl {
     // Load the sound on success.
     //var success = ;
 
-    Howler.ctx.decodeAudioData(arraybuffer).then((buffer) {
+    Howler.ctx!.decodeAudioData(arraybuffer).then((buffer) {
       if (buffer != null && _sounds.isNotEmpty) {
         _cache[_src] = buffer;
         _loadSound(buffer);
@@ -2257,12 +2261,14 @@ class Howl {
   void _loadSound(AudioBuffer buffer) {
     // Set the duration.
     if (buffer != null && (_duration == null || _duration == 0)) {
-      _duration = buffer.duration;
+      _duration = buffer.duration as double?;
     }
 
     // Setup a sprite if none is defined.
     if (_sprite.isEmpty) {
-      _sprite = {'__default': _HowlSpriteParams(0, (_duration * 1000).floor())};
+      _sprite = {
+        '__default': _HowlSpriteParams(0, (_duration! * 1000).floor())
+      };
     }
 
     // Fire the loaded event.
@@ -2278,9 +2284,9 @@ class Howl {
   /// @param  {Number} id    Sound ID.
   /// @param  {Number} msg   Message to go with event.
   /// @return {Howl}
-  void _emit(String eventType, [int id, String msg]) {
-    var events = _getEventListeners(eventType);
-    List<_HowlEventListenerWrapper> offEvents;
+  void _emit(String eventType, [int? id, String? msg]) {
+    var events = _getEventListeners(eventType)!;
+    List<_HowlEventListenerWrapper>? offEvents;
 
     // Loop through event store and fire all functions.
     for (var i = events.length - 1; i >= 0; i--) {
@@ -2314,7 +2320,7 @@ class Howl {
   /// These will be called in sequence, with the next only firing
   /// after the previous has finished executing (even if async like play).
   /// @return {Howl}
-  void _loadQueue([String event]) {
+  void _loadQueue([String? event]) {
     if (_queue.isNotEmpty) {
       var task = _queue[0];
 
@@ -2341,9 +2347,9 @@ class Howl {
     // believes it has completed, before ending the playback.
     if (!_webAudio &&
         sound._node != null &&
-        !sound._node.audio.paused &&
-        !sound._node.audio.ended &&
-        sound._node.audio.currentTime < sound._stop) {
+        !sound._node!.audio!.paused &&
+        !sound._node!.audio!.ended &&
+        sound._node!.audio!.currentTime < sound._stop) {
       Timer(Duration(milliseconds: 100), () {
         _ended(sound);
       });
@@ -2352,7 +2358,7 @@ class Howl {
     }
 
     // Should this sound loop?
-    var loop = sound._loop || _sprite[sprite].loop;
+    var loop = sound._loop! || _sprite[sprite]!.loop!;
 
     // Fire the ended event.
     _emit('end', sound._id);
@@ -2367,9 +2373,9 @@ class Howl {
       _emit('play', sound._id);
       sound._seek = sound._start;
       sound._rateSeek = 0;
-      sound._playStart = Howler.ctx.currentTime;
+      sound._playStart = Howler.ctx!.currentTime as double?;
 
-      var timeout = ((sound._stop - sound._start) * 1000) ~/ sound._rate.abs();
+      var timeout = ((sound._stop - sound._start) * 1000) ~/ sound._rate!.abs();
 
       _endTimers[sound._id] = Timer(Duration(milliseconds: timeout), () {
         _ended(sound);
@@ -2385,7 +2391,7 @@ class Howl {
       _clearTimer(sound._id);
 
       // Clean up the buffer source.
-      _cleanBuffer(sound._node);
+      _cleanBuffer(sound._node!);
 
       // Attempt to auto-suspend AudioContext if no sounds are still playing.
       Howler._autoSuspend();
@@ -2410,7 +2416,8 @@ class Howl {
       } else {
         var sound = _soundById(id);
         if (sound != null && sound._node != null) {
-          sound._node.eventTarget.removeEventListener('ended', endTimer, false);
+          sound._node!.eventTarget!
+              .removeEventListener('ended', endTimer, false);
         }
       }
 
@@ -2421,7 +2428,7 @@ class Howl {
   /// Return the sound identified by this ID, or return null.
   /// @param  {Number} id Sound ID
   /// @return {Object}    Sound object or null.
-  Sound _soundById(int id) {
+  Sound? _soundById(int? id) {
     // Loop through all sounds and find the one with this ID.
     for (var i = 0; i < _sounds.length; i++) {
       var sound = _sounds[i];
@@ -2440,7 +2447,7 @@ class Howl {
     for (var i = 0; i < _sounds.length; i++) {
       var sound = _sounds[i];
 
-      if (sound._ended) {
+      if (sound._ended!) {
         return sound.reset();
       }
     }
@@ -2461,7 +2468,7 @@ class Howl {
 
     // Count the number of inactive sounds.
     for (var i = 0; i < _sounds.length; i++) {
-      if (_sounds[i]._ended) {
+      if (_sounds[i]._ended!) {
         cnt++;
       }
     }
@@ -2472,12 +2479,12 @@ class Howl {
 
       var sound = _sounds[i];
 
-      if (sound._ended) {
+      if (sound._ended!) {
         // Disconnect the audio source when using Web Audio.
         if (_webAudio &&
             sound._node != null &&
-            sound._node.bufferSource != null) {
-          sound._node.bufferSource.disconnect(0);
+            sound._node!.bufferSource != null) {
+          sound._node!.bufferSource!.disconnect(0);
         }
 
         // Remove sounds until we have the pool size.
@@ -2490,9 +2497,9 @@ class Howl {
   /// Get all ID's from the sounds pool.
   /// @param  {Number} id Only return one ID if one is passed.
   /// @return {Array}    Array of IDs.
-  List<int> _getSoundIds([int id]) {
+  List<int?> _getSoundIds([int? id]) {
     if (id == null) {
-      var ids = <int>[];
+      var ids = <int?>[];
 
       for (var i = 0; i < _sounds.length; i++) {
         ids.add(_sounds[i]._id);
@@ -2509,24 +2516,24 @@ class Howl {
   /// @return {Howl}
   void _refreshBuffer(Sound sound) {
     // Setup the buffer source for playback.
-    sound._node.bufferSource = Howler.ctx.createBufferSource();
-    sound._node.bufferSource.buffer = _cache[_src];
+    sound._node!.bufferSource = Howler.ctx!.createBufferSource();
+    sound._node!.bufferSource!.buffer = _cache[_src];
 
     // Connect to the correct node.
     if (sound._panner != null) {
-      sound._node.bufferSource.connectNode(sound._panner);
+      sound._node!.bufferSource!.connectNode(sound._panner!);
     } else {
-      sound._node.bufferSource.connectNode(sound._node.gainNode);
+      sound._node!.bufferSource!.connectNode(sound._node!.gainNode!);
     }
 
     // Setup looping and playback rate.
-    sound._node.bufferSource.loop = sound._loop;
-    if (sound._loop) {
-      sound._node.bufferSource.loopStart = sound._start;
-      sound._node.bufferSource.loopEnd = sound._stop;
+    sound._node!.bufferSource!.loop = sound._loop;
+    if (sound._loop!) {
+      sound._node!.bufferSource!.loopStart = sound._start;
+      sound._node!.bufferSource!.loopEnd = sound._stop;
     }
-    sound._node.bufferSource.playbackRate
-        .setValueAtTime(sound._rate, Howler.ctx.currentTime);
+    sound._node!.bufferSource!.playbackRate!
+        .setValueAtTime(sound._rate!, Howler.ctx!.currentTime!);
   }
 
   /// Prevent memory leaks by cleaning up the buffer source after playback.
@@ -2535,11 +2542,11 @@ class Howl {
   void _cleanBuffer(_HowlAudioNode node) {
     if (Howler._scratchBuffer != null && node.bufferSource != null) {
       //node.bufferSource.onEnded = null ; TODO
-      node.bufferSource.disconnect(0);
+      node.bufferSource!.disconnect(0);
 
-      if (Howler.isIOS) {
+      if (Howler.isIOS!) {
         try {
-          node.bufferSource.buffer = Howler._scratchBuffer;
+          node.bufferSource!.buffer = Howler._scratchBuffer;
           // ignore: empty_catches
         } catch (e) {}
       }
@@ -2556,30 +2563,30 @@ class Howl {
 }
 
 class _HowlAudioNode {
-  AudioElement audio;
-  GainNode gainNode;
+  AudioElement? audio;
+  GainNode? gainNode;
 
-  AudioBufferSourceNode bufferSource;
-  bool _unlocked;
+  AudioBufferSourceNode? bufferSource;
+  late bool _unlocked;
 
-  EventTarget get eventTarget => gainNode ?? audio;
+  EventTarget? get eventTarget => gainNode ?? audio;
 
   _HowlAudioNode.audio(this.audio);
 
   _HowlAudioNode.gain(this.gainNode);
 
-  String get src => audio.src;
+  String get src => audio!.src;
 
-  set src(String src) => audio.src = src;
+  set src(String src) => audio!.src = src;
 
-  num get duration => audio.duration;
+  num get duration => audio!.duration;
 
   bool get isInfinityDuration {
     var duration = this.duration;
     return duration != null && duration.isInfinite;
   }
 
-  void load() => audio.load();
+  void load() => audio!.load();
 }
 
 class Sound {
@@ -2588,32 +2595,32 @@ class Sound {
   double _start = 0;
   double _stop = 0;
 
-  double _volume;
+  double? _volume;
 
-  bool _paused;
-  bool _ended;
-  int _id;
-  String _sprite;
-  double _seek;
-  double _rateSeek;
-  double _rate;
+  bool? _paused;
+  bool? _ended;
+  int? _id;
+  String? _sprite;
+  double? _seek;
+  double? _rateSeek;
+  double? _rate;
 
-  bool _loop;
+  bool? _loop;
 
-  bool _muted;
+  bool? _muted;
 
-  _HowlAudioNode _node;
+  _HowlAudioNode? _node;
 
-  AudioNode _panner;
+  AudioNode? _panner;
 
-  Timer _interval;
+  Timer? _interval;
 
-  double _fadeTo;
+  double? _fadeTo;
 
-  double _playStart;
+  double? _playStart;
 
-  EventListener _loadFn;
-  EventListener _errorFn;
+  EventListener? _loadFn;
+  EventListener? _errorFn;
 
   Sound(this._parent) {
     var parent = _parent;
@@ -2642,34 +2649,34 @@ class Sound {
   /// @return {Sound}
   Sound create() {
     var parent = _parent;
-    var volume = (Howler._muted || _muted || _parent._muted) ? 0 : _volume;
+    var volume = (Howler._muted || _muted! || _parent._muted!) ? 0 : _volume;
 
     if (parent._webAudio) {
       // Create the gain node for controlling volume (the source will connect to this).
-      _node = _HowlAudioNode.gain(Howler.ctx.createGain());
+      _node = _HowlAudioNode.gain(Howler.ctx!.createGain());
 
-      _node.gainNode.gain.setValueAtTime(volume, Howler.ctx.currentTime);
+      _node!.gainNode!.gain!.setValueAtTime(volume!, Howler.ctx!.currentTime!);
       //this._node.gainNode.paused = true; TODO
-      _node.gainNode.connectNode(Howler.masterGain);
+      _node!.gainNode!.connectNode(Howler.masterGain);
     } else if (!Howler.noAudio) {
       // Get an unlocked Audio object from the pool.
       _node = _HowlAudioNode.audio(Howler._obtainHtml5Audio());
 
       // Listen for errors (http://dev.w3.org/html5/spec-author-view/spec.html#mediaerror).
       _errorFn = _errorListener;
-      _node.audio.addEventListener('error', _errorFn, false);
+      _node!.audio!.addEventListener('error', _errorFn, false);
 
       // Listen for 'canplaythrough' event to let us know the sound is ready.
       _loadFn = _loadListener;
-      _node.audio.addEventListener(Howler._canPlayEvent, _loadFn, false);
+      _node!.audio!.addEventListener(Howler._canPlayEvent, _loadFn, false);
 
       // Setup the new audio node.
-      _node.audio.src = parent._src[0];
-      _node.audio.preload = parent._preload ? 'auto' : 'none';
-      _node.audio.volume = volume * Howler.volume();
+      _node!.audio!.src = parent._src![0];
+      _node!.audio!.preload = parent._preload ? 'auto' : 'none';
+      _node!.audio!.volume = volume! * Howler.volume();
 
       // Begin loading the source.
-      _node.audio.load();
+      _node!.audio!.load();
     }
 
     return this;
@@ -2700,11 +2707,15 @@ class Sound {
   /// HTML5 Audio error listener callback.
   void _errorListener(_) {
     // Fire an error event and pass back the code.
-    _parent._emit('loaderror', _id,
-        _node.audio.error != null ? _node.audio.error.code : '0');
+    _parent._emit(
+        'loaderror',
+        _id,
+        _node!.audio!.error != null
+            ? _node!.audio!.error!.code as String?
+            : '0');
 
     // Clear the event listener.
-    _node.eventTarget.removeEventListener('error', _errorFn, false);
+    _node!.eventTarget!.removeEventListener('error', _errorFn, false);
   }
 
   /// HTML5 Audio canplaythrough listener callback.
@@ -2712,12 +2723,12 @@ class Sound {
     var parent = _parent;
 
     // Round up the duration to account for the lower precision in HTML5 Audio.
-    parent._duration = ((_node.audio.duration * 10) / 10).ceilToDouble();
+    parent._duration = ((_node!.audio!.duration * 10) / 10).ceilToDouble();
 
     // Setup a sprite if none is defined.
     if (parent._sprite.isEmpty) {
       parent._sprite = {
-        '__default': _HowlSpriteParams(0, (parent._duration * 1000).floor())
+        '__default': _HowlSpriteParams(0, (parent._duration! * 1000).floor())
       };
     }
 
@@ -2728,7 +2739,8 @@ class Sound {
     }
 
     // Clear the event listener.
-    _node.eventTarget.removeEventListener(Howler._canPlayEvent, _loadFn, false);
+    _node!.eventTarget!
+        .removeEventListener(Howler._canPlayEvent, _loadFn, false);
   }
 
   Howl get parent => _parent;
@@ -2742,23 +2754,23 @@ class Sound {
 
   double get stop => _stop;
 
-  double get volume => _volume;
+  double? get volume => _volume;
 
-  bool get paused => _paused;
+  bool? get paused => _paused;
 
-  bool get ended => _ended;
+  bool? get ended => _ended;
 
-  int get id => _id;
+  int? get id => _id;
 
-  String get sprite => _sprite;
+  String? get sprite => _sprite;
 
-  double get rate => _rate;
+  double? get rate => _rate;
 
-  bool get loop => _loop;
+  bool? get loop => _loop;
 
-  bool get muted => _muted;
+  bool? get muted => _muted;
 
-  double get playStart => _playStart;
+  double? get playStart => _playStart;
 }
 
 /// Setup the audio context when available, or switch to HTML5 Audio mode.
@@ -2780,10 +2792,10 @@ void _setupAudioContext() {
 
   // Create and expose the master GainNode when using Web Audio (useful for plugins or advanced usage).
   if (Howler.usingWebAudio) {
-    Howler.masterGain = Howler.ctx.createGain();
-    Howler.masterGain.gain.setValueAtTime(
-        Howler._muted ? 0 : Howler._volume, Howler.ctx.currentTime);
-    Howler.masterGain.connectNode(Howler.ctx.destination);
+    Howler.masterGain = Howler.ctx!.createGain();
+    Howler.masterGain.gain!.setValueAtTime(
+        Howler._muted ? 0 : Howler._volume, Howler.ctx!.currentTime!);
+    Howler.masterGain.connectNode(Howler.ctx!.destination!);
   }
 
   // Re-run the setup on Howler.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: howler
 description: Audio library for the modern web. This makes working with audio in Dart easy and reliable across many platforms. (Port of howler.js to Dart)
-version: 1.1.2
+version: 2.0.0
 homepage: https://github.com/gmpassos/howler.dart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,11 @@ version: 1.1.2
 homepage: https://github.com/gmpassos/howler.dart
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  swiss_knife: ^2.5.8
-    #path: ../swiss_knife
+  swiss_knife: ^3.1.6
 
 dev_dependencies:
-  pedantic: ^1.9.0
-  test: ^1.5.1
+  pedantic: ^1.11.1
+  test: ^1.24.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.0
 homepage: https://github.com/gmpassos/howler.dart
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   swiss_knife: ^3.1.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.1.2
 homepage: https://github.com/gmpassos/howler.dart
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
   swiss_knife: ^3.1.6

--- a/test/howler_test.dart
+++ b/test/howler_test.dart
@@ -12,7 +12,10 @@ Future<void> _sleep(int sleepMs) async {
 }
 
 Future<void> _sleepUntilCondition(
-    String conditionName, int timeout, bool Function() conditionTester) async {
+  String conditionName,
+  int timeout,
+  bool Function() conditionTester,
+) async {
   print('-------------------------------------');
   print('SLEEP UNTIL CONDITION[$conditionName]> timeout: $timeout');
 
@@ -36,7 +39,8 @@ Future<void> _sleepUntilCondition(
       }
 
       print(
-          'sleep: $sleep ; elapsed: $elapsed ; remaining: $remaining ; timeout: $timeout');
+        'sleep: $sleep ; elapsed: $elapsed ; remaining: $remaining ; timeout: $timeout',
+      );
       await _sleep(sleep);
     } else {
       break;
@@ -52,9 +56,12 @@ void main() {
     test('Basic load', () async {
       print('Uri Base: ${getUriBase()}');
 
-      var howl = Howl(src: [
-        'piano-sample.mp3',
-      ], loop: false, preload: false, volume: 0.60);
+      var howl = Howl(
+        src: ['piano-sample.mp3'],
+        loop: false,
+        preload: false,
+        volume: 0.60,
+      );
 
       prints('Howl: $howl');
 
@@ -74,7 +81,10 @@ void main() {
       expect(howl.playing(), isTrue);
 
       await _sleepUntilCondition(
-          'howl.getVolume() == 0.90', 5000, () => howl.getVolume() == 0.90);
+        'howl.getVolume() == 0.90',
+        5000,
+        () => howl.getVolume() == 0.90,
+      );
       expect(howl.getVolume(), equals(0.90));
     });
   });

--- a/test/howler_test.dart
+++ b/test/howler_test.dart
@@ -1,15 +1,17 @@
+@TestOn('browser')
+library howler_test;
+
 import 'package:howler/howler.dart';
 import 'package:swiss_knife/swiss_knife.dart';
 import 'package:test/test.dart';
 
-@TestOn('browser')
-void _sleep(int sleepMs) async {
+Future<void> _sleep(int sleepMs) async {
   if (sleepMs <= 0) return;
   print('SLEEP> ${sleepMs}ms');
   await Future.delayed(Duration(milliseconds: sleepMs), () {});
 }
 
-void _sleepUntilCondition(
+Future<void> _sleepUntilCondition(
     String conditionName, int timeout, bool Function() conditionTester) async {
   print('-------------------------------------');
   print('SLEEP UNTIL CONDITION[$conditionName]> timeout: $timeout');


### PR DESCRIPTION
Hey, feel free to ignore this if you deem the project unmaintained. But I'm looking at an ancient side-project of mine and decided to upgrade it to modern Dart. So I decided to upgrade `howler` as well. I mean, it's still probably the easiest-to-use, fewest-dependencies-required audio package when you just want to play files on the web (I think?).

The migration is literally the least-work-required migration: I ran the `dart migrate` tool and, IIRC, merely accepted all proposed changes. This probably means the code could be much improved, but frankly, since this is originally a JavaScript library, it would require a major overhaul. I remember the tool making something like 4000 changes, as null is just everywhere.

Anyway, no worries if you decide not to use this. Some packages should be allowed to retire.

Thanks for making this package in the first place!